### PR TITLE
Handle profile lookup without implicit creation

### DIFF
--- a/traveltech_ready_to_run_plus/backend/src/profile/profile.controller.ts
+++ b/traveltech_ready_to_run_plus/backend/src/profile/profile.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Req } from '@nestjs/common';
+import { Request } from 'express';
+import { ProfileService } from './profile.service';
+
+@Controller('profile')
+export class ProfileController {
+  constructor(private readonly profileService: ProfileService) {}
+
+  @Get('me')
+  me(@Req() req: Request) {
+    const userId = (req.headers['x-user-id'] as string) || 'anonymous';
+    return this.profileService.me(userId);
+  }
+}

--- a/traveltech_ready_to_run_plus/backend/src/profile/profile.module.ts
+++ b/traveltech_ready_to_run_plus/backend/src/profile/profile.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ProfileController } from './profile.controller';
+import { ProfileService } from './profile.service';
+import { PrismaService } from '../prisma.service';
+
+@Module({
+  controllers: [ProfileController],
+  providers: [ProfileService, PrismaService],
+})
+export class ProfileModule {}

--- a/traveltech_ready_to_run_plus/backend/src/profile/profile.service.ts
+++ b/traveltech_ready_to_run_plus/backend/src/profile/profile.service.ts
@@ -1,0 +1,34 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma.service';
+
+export const PROFILE_RELATIONS: Prisma.UserInclude = {
+  badges: {
+    include: {
+      badge: true,
+    },
+    orderBy: {
+      ts: 'desc',
+    },
+  },
+};
+
+export type ProfileWithRelations = Prisma.UserGetPayload<{ include: typeof PROFILE_RELATIONS }>;
+
+@Injectable()
+export class ProfileService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async me(userId: string): Promise<ProfileWithRelations> {
+    const profile = await this.prisma.user.findUnique({
+      where: { id: userId },
+      include: PROFILE_RELATIONS,
+    });
+
+    if (!profile) {
+      throw new NotFoundException('User profile not found');
+    }
+
+    return profile;
+  }
+}

--- a/traveltech_ready_to_run_plus/backend/test/profile.service.spec.ts
+++ b/traveltech_ready_to_run_plus/backend/test/profile.service.spec.ts
@@ -1,0 +1,32 @@
+import { NotFoundException } from '@nestjs/common';
+import { ProfileService, PROFILE_RELATIONS } from '../src/profile/profile.service';
+
+describe('ProfileService', () => {
+  const findUnique = jest.fn();
+  const prismaMock = {
+    user: { findUnique },
+  } as any;
+  const service = new ProfileService(prismaMock);
+
+  beforeEach(() => {
+    findUnique.mockReset();
+  });
+
+  it('returns the existing profile when found', async () => {
+    const profile = { id: 'user-1', xp: 42, level: 3, badges: [] };
+    findUnique.mockResolvedValueOnce(profile);
+
+    await expect(service.me('user-1')).resolves.toBe(profile);
+
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      include: PROFILE_RELATIONS,
+    });
+  });
+
+  it('throws NotFoundException when the user is absent', async () => {
+    findUnique.mockResolvedValueOnce(null);
+
+    await expect(service.me('missing-user')).rejects.toBeInstanceOf(NotFoundException);
+  });
+});


### PR DESCRIPTION
## Summary
- add a profile module that loads existing users with Prisma `findUnique` and keeps the badge include/order rules
- propagate `NotFoundException` from the profile controller when a profile is missing
- cover existing and missing profile scenarios with unit tests

## Testing
- npm run test *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_68e0f6a4ace4832a87fa79d98599f44c